### PR TITLE
adding "minProfitMarginThreshold": 0 to secretes template generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ The contents of the file should mirror the following:
         },
         "sell": {
             "rsiThreshold": 0,
+            "minProfitMarginThreshold": 0,
             "profitMarginThreshold": 0
         }
     },

--- a/src/app.py
+++ b/src/app.py
@@ -41,6 +41,7 @@ def get_secrets():
             },
             "sell": {
                 "rsiThreshold": 0,
+                "minProfitMarginThreshold": 0,
                 "profitMarginThreshold": 0
             }
         },


### PR DESCRIPTION

- [src/app.py] adding "minProfitMarginThreshold": 0 to secretes template, because it was missing for auto generation of the secretes.json file

- [README.md] updating README.md to include the "minProfitMarginThreshold": 0 in the secretes.json setup file