### PR TITLE
NEW FEATURE: Enable selling at loss to prevent long holding

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ The contents of the file should mirror the following:
             * `maxOpenTrades` is the maximum amount of open trades the bot is allowed to have at one time 
         * **`sell`**: 
             * `lossMarginThreshold` is the lower loss margin threshold. Coin pairs with a profit margin lower than this 
-            will be sold regardless of its RSI. If this value is left out or set to zero (`0`), this parameter will be ignored 
+            will be sold regardless of its RSI. If this value is omitted or set to zero (`0`), this parameter will be ignored 
             and coin pairs will not be sold at a loss
             * `rsiThreshold` is the lower RSI sell threshold. An RSI higher than this will result in a sell signal
             * `minProfitMarginThreshold` is the upper minimum profit margin sell threshold. Coin pairs with a profit margin 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ and Unit Price.
 
 #### Coming Soon:
 * Bollinger Bands
+* Moving Average
 
 #### Shoutouts:
 * Bittrex for an awesome API

--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ The contents of the file should mirror the following:
                 "maxOpenTrades": 0
             },
             "sell": {
+                "lossMarginThreshold": 0,
                 "rsiThreshold": 0,
                 "minProfitMarginThreshold": 0,
                 "profitMarginThreshold": 0
@@ -130,15 +131,18 @@ The contents of the file should mirror the following:
             this will not be considered for buying
             * `minimumUnitPrice` is the lower unit price buy threshold. Coin pairs with a unit price lower than this will not 
             be considered for buying 
-    3) `maxOpenTrades` is the maximum amount of open trades the bot is allowed to have at one time 
+            * `maxOpenTrades` is the maximum amount of open trades the bot is allowed to have at one time 
         * **`sell`**: 
+            * `lossMarginThreshold` is the lower loss margin threshold. Coin pairs with a profit margin lower than this 
+            will be sold regardless of its RSI. If this value is left out or set to zero (`0`), this parameter will be ignored 
+            and coin pairs will not be sold at a loss
             * `rsiThreshold` is the lower RSI sell threshold. An RSI higher than this will result in a sell signal
             * `minProfitMarginThreshold` is the upper minimum profit margin sell threshold. Coin pairs with a profit margin 
             lower than this will not be sold
             * `profitMarginThreshold` is the upper profit margin sell threshold. Coin pairs with a profit margin higher than 
             this will be sold regardless of its RSI
     
-    4) To use the **Pause** functionality, you need to setup the following:
+    3) To use the **Pause** functionality, you need to setup the following:
         * **`buy`**: 
             * `rsiThreshold` is the lower RSI pause threshold. An RSI higher than this will result in the coin pair not being 
             tracked for `pauseTime` minutes
@@ -147,6 +151,8 @@ The contents of the file should mirror the following:
             * `profitMarginThreshold` is the upper profit margin pause threshold. A profit margin lower than this will result 
             in the coin pair not being tracked for `pauseTime` minutes
             * `pauseTime` is the amount of minutes to pause coin pair tracking by
+            If you prefer to sell at a small loss rather than holding onto (pausing) sell coin pairs, the `lossMarginThreshold` 
+            **trade** parameter should be set appropriately and then the `sell` **pause** parameter may be omitted.
 
 
 ## How to run
@@ -175,6 +181,7 @@ successful trading parameters can be found below:
             "maxOpenTrades": 3
         },
         "sell": {
+            "lossMarginThreshold": -1.5,
             "rsiThreshold": 50,
             "minProfitMarginThreshold": 0.5,
             "profitMarginThreshold": 2.5
@@ -210,9 +217,11 @@ def check_buy_parameters(rsi, day_volume, current_buy_price):
     :return: Boolean indicating if the buy conditions have been met
     :rtype : bool
     """
-    return (rsi is not None and rsi <= buy_trade_params["rsiThreshold"] and
-            day_volume >= buy_trade_params["24HourVolumeThreshold"] and
-            current_buy_price > buy_trade_params["minimumUnitPrice"])
+    rsi_check = rsi is not None and rsi <= buy_trade_params["buy"]["rsiThreshold"]
+    day_volume_check = day_volume >= buy_trade_params["buy"]["24HourVolumeThreshold"]
+    current_buy_price_check = current_buy_price >= buy_trade_params["buy"]["minimumUnitPrice"]
+    
+    return rsi_check and day_volume_check and current_buy_price_check
 
 
 def check_sell_parameters(rsi, profit_margin):
@@ -227,9 +236,13 @@ def check_sell_parameters(rsi, profit_margin):
     :return: Boolean indicating if the sell conditions have been met
     :rtype : bool
     """
-    return ((rsi is not None and rsi >= sell_trade_params["rsiThreshold"] and
-             profit_margin > sell_trade_params["minProfitMarginThreshold"]) or
-            profit_margin > sell_trade_params["profitMarginThreshold"])
+    rsi_check = rsi is not None and rsi >= sell_trade_params["sell"]["rsiThreshold"]
+    lower_profit_check = profit_margin >= sell_trade_params["sell"]["minProfitMarginThreshold"]        
+    upper_profit_check = profit_margin >= sell_trade_params["sell"]["profitMarginThreshold"]
+    loss_check = (sell_trade_params["lossMarginThreshold"] is not None and
+                  0 > sell_trade_params["lossMarginThreshold"] >= profit_margin)
+
+    return (rsi_check and lower_profit_check) or upper_profit_check or loss_check
 ```
 
 See the source code for a more detailed description.

--- a/src/app.py
+++ b/src/app.py
@@ -52,6 +52,7 @@ def get_settings():
                 "maxOpenTrades": 0
             },
             "sell": {
+                "lossMarginThreshold": 0,
                 "rsiThreshold": 0,
                 "minProfitMarginThreshold": 0,
                 "profitMarginThreshold": 0

--- a/src/messenger.py
+++ b/src/messenger.py
@@ -66,10 +66,8 @@ class Messenger(object):
                 "emoji": ":heavy_minus_sign:",
                 "message": "*Buy on {}*\n>>>\n_RSI: *{}*_\n_24 Hour Volume: *{} {}*_"},
             "sell": {
-                "emoji": {
-                    "profit": ":heavy_check_mark:",
-                    "loss": ":x:"
-                },
+                "profit_emoji": ":heavy_check_mark:",
+                "loss_emoji": ":x:",
                 "message": "*Sell on {}*\n>>>\n_RSI: *{}*_\n_Profit Margin: *{}%*_"
             }
         }
@@ -212,11 +210,11 @@ class Messenger(object):
         :param profit_margin: Profit made on the trade
         :type profit_margin: float
         """
-        emoji = self.slack_str["sell"]["emoji"]["profit"]
+        emoji_type = "profit_emoji"
         if profit_margin <= 0:
-            emoji_type = "loss"
+            emoji_type = "loss_emoji"
 
-        slack_emoji = self.slack_str["sell"]["emoji"][emoji_type] * 8 + "\n"
+        slack_emoji = self.slack_str["sell"][emoji_type] * 8 + "\n"
         slack_message = slack_emoji + self.slack_str["sell"]["message"].format(coin_pair, floor(rsi),
                                                                                round(profit_margin, 2))
         self.send_slack(slack_message)

--- a/src/messenger.py
+++ b/src/messenger.py
@@ -88,7 +88,8 @@ class Messenger(object):
             "typeError": "Type error occurred.",
             "keyError": "Invalid key provided to obj/dict.",
             "valueError": "Value error occurred.",
-            "unknown": "An unknown exception occurred."
+            "unknown": "An unknown exception occurred.",
+            "general": "See the latest log file for more information."
         }
 
         self.order_error_str = "Failed to complete order with UUID {} within {} seconds on {} market. URL: {}"
@@ -356,6 +357,7 @@ class Messenger(object):
         if will_exit:
             suffix = " Exiting program."
         cprint("\n" + self.exception_error_str[error_type] + suffix + "\n", "red", attrs=["bold"])
+        cprint("\n" + self.exception_error_str["general"] + "\n", "grey", attrs=["bold"])
         self.play_beep()
 
     def print_order_error(self, order_uuid, trade_time_limit, coin_pair):

--- a/src/trader.py
+++ b/src/trader.py
@@ -155,8 +155,8 @@ class Trader(object):
         rsi_check = rsi >= self.trade_params["sell"]["rsiThreshold"]
         lower_profit_check = profit_margin >= self.trade_params["sell"]["minProfitMarginThreshold"]
         upper_profit_check = profit_margin >= self.trade_params["sell"]["profitMarginThreshold"]
-        loss_check = (self.trade_params["lossMarginThreshold"] is not None and
-                      0 > self.trade_params["lossMarginThreshold"] >= profit_margin)
+        loss_check = ("sell" in self.trade_params and self.trade_params["sell"]["lossMarginThreshold"] is not None and
+                      0 > self.trade_params["sell"]["lossMarginThreshold"] >= profit_margin)
 
         return (rsi_check and lower_profit_check) or upper_profit_check or loss_check
 

--- a/src/trader.py
+++ b/src/trader.py
@@ -155,7 +155,7 @@ class Trader(object):
         rsi_check = rsi >= self.trade_params["sell"]["rsiThreshold"]
         lower_profit_check = profit_margin >= self.trade_params["sell"]["minProfitMarginThreshold"]
         upper_profit_check = profit_margin >= self.trade_params["sell"]["profitMarginThreshold"]
-        loss_check = ("sell" in self.trade_params and self.trade_params["sell"]["lossMarginThreshold"] is not None and
+        loss_check = ("lossMarginThreshold" in self.trade_params["sell"] and
                       0 > self.trade_params["sell"]["lossMarginThreshold"] >= profit_margin)
 
         return (rsi_check and lower_profit_check) or upper_profit_check or loss_check

--- a/src/trader.py
+++ b/src/trader.py
@@ -40,7 +40,7 @@ class Trader(object):
         if self.Database.check_resume(self.pause_params["buy"]["pauseTime"], "buy"):
             self.Database.store_coin_pairs(self.get_markets("BTC"))
             self.Messenger.print_resume_pause(len(self.Database.app_data["coinPairs"]), "buy")
-        if self.Database.check_resume(self.pause_params["sell"]["pauseTime"], "sell"):
+        if "sell" in self.pause_params and self.Database.check_resume(self.pause_params["sell"]["pauseTime"], "sell"):
             self.Messenger.print_resume_pause(self.Database.app_data["pausedTrackedCoinPairs"], "sell")
             self.Database.resume_sells()
 
@@ -76,15 +76,18 @@ class Trader(object):
         day_volume = self.get_current_24hr_volume(coin_pair)
         current_buy_price = self.get_current_price(coin_pair, "ask")
 
+        if rsi is None:
+            return
+
         if self.check_buy_parameters(rsi, day_volume, current_buy_price):
             buy_stats = {
                 "rsi": rsi,
                 "24HrVolume": day_volume
             }
             self.buy(coin_pair, self.trade_params["buy"]["btcAmount"], current_buy_price, buy_stats)
-        elif rsi is not None and rsi <= self.pause_params["buy"]["rsiThreshold"]:
+        elif rsi <= self.pause_params["buy"]["rsiThreshold"]:
             self.Messenger.print_no_buy(coin_pair, rsi, day_volume, current_buy_price)
-        elif rsi is not None:
+        else:
             self.Messenger.print_pause(coin_pair, rsi, self.pause_params["buy"]["pauseTime"], "buy")
             self.Database.pause_buy(coin_pair)
 
@@ -128,9 +131,11 @@ class Trader(object):
         :return: Boolean indicating if the buy conditions have been met
         :rtype : bool
         """
-        return (rsi is not None and rsi <= self.trade_params["buy"]["rsiThreshold"] and
-                day_volume >= self.trade_params["buy"]["24HourVolumeThreshold"] and
-                current_buy_price > self.trade_params["buy"]["minimumUnitPrice"])
+        rsi_check = rsi <= self.trade_params["buy"]["rsiThreshold"]
+        day_volume_check = day_volume >= self.trade_params["buy"]["24HourVolumeThreshold"]
+        current_buy_price_check = current_buy_price >= self.trade_params["buy"]["minimumUnitPrice"]
+
+        return rsi_check and day_volume_check and current_buy_price_check
 
     def check_sell_parameters(self, rsi, profit_margin):
         """
@@ -144,9 +149,13 @@ class Trader(object):
         :return: Boolean indicating if the sell conditions have been met
         :rtype : bool
         """
-        return ((rsi is not None and rsi >= self.trade_params["sell"]["rsiThreshold"] and
-                 profit_margin > self.trade_params["sell"]["minProfitMarginThreshold"]) or
-                profit_margin > self.trade_params["sell"]["profitMarginThreshold"])
+        rsi_check = rsi >= self.trade_params["sell"]["rsiThreshold"]
+        lower_profit_check = profit_margin >= self.trade_params["sell"]["minProfitMarginThreshold"]
+        upper_profit_check = profit_margin >= self.trade_params["sell"]["profitMarginThreshold"]
+        loss_check = (self.trade_params["lossMarginThreshold"] is not None and
+                      0 > self.trade_params["lossMarginThreshold"] >= profit_margin)
+
+        return (rsi_check and lower_profit_check) or upper_profit_check or loss_check
 
     def buy(self, coin_pair, btc_quantity, price, stats, trade_time_limit=2):
         """

--- a/src/trader.py
+++ b/src/trader.py
@@ -105,17 +105,20 @@ class Trader(object):
         current_sell_price = self.get_current_price(coin_pair, "bid")
         profit_margin = self.Database.get_profit_margin(coin_pair, current_sell_price)
 
+        if rsi is None:
+            return
+
         if self.check_sell_parameters(rsi, profit_margin):
             sell_stats = {
                 "rsi": rsi,
                 "profitMargin": profit_margin
             }
             self.sell(coin_pair, current_sell_price, sell_stats)
-        elif rsi is not None and profit_margin >= self.pause_params["sell"]["profitMarginThreshold"]:
-            self.Messenger.print_no_sell(coin_pair, rsi, profit_margin, current_sell_price)
-        elif rsi is not None:
+        elif "sell" in self.pause_params and profit_margin <= self.pause_params["sell"]["profitMarginThreshold"]:
             self.Messenger.print_pause(coin_pair, profit_margin, self.pause_params["sell"]["pauseTime"], "sell")
             self.Database.pause_sell(coin_pair)
+        else:
+            self.Messenger.print_no_sell(coin_pair, rsi, profit_margin, current_sell_price)
 
     def check_buy_parameters(self, rsi, day_volume, current_buy_price):
         """


### PR DESCRIPTION
I decided to add user customisable functionality which allows the bot to selling at a loss to avoid holding onto bad trades for too long. Coin pairs with a profit margin lower than a user defined value will be sold regardless of its RSI. If this value omitted out or set to zero (`0`), this functionality will be ignored and coin pairs will not be sold at a loss - hence there will also be no breaking changes to existing bots.

I also decided to leave the sell pausing functionality in case users wish to continue using it and to make sure there won't be any breaking changes.

_See the README for more information on how to use the new functionality._